### PR TITLE
Add dynamic GitHub-backed docs server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# DevVoxel-Docs
+# DevVoxel Docs
+
+Dieses Projekt stellt einen kleinen Node.js-Server bereit, der Markdown-Dateien direkt aus einem GitHub-Repository lädt und sie als HTML rendert. Die Startseite `/` zeigt automatisch die Datei `README.md`, sodass das Wiki stets den aktuellen Stand des Repos widerspiegelt.
+
+Eine Seitenleiste (`sidebar.md`) hält Verweise auf weitere Dokumentationsseiten bereit. Eigene Seiten können als Markdown-Dateien angelegt und in der Sidebar verlinkt werden.
+
+## Nutzung
+
+1. Node.js (Version 18 oder höher) installieren.
+2. Optional die Ziel‑Repository über Umgebungsvariablen festlegen:
+   - `GITHUB_OWNER` – Besitzer des Repos (Standard: `DevVoxel`)
+   - `GITHUB_REPO` – Name des Repos (Standard: `DevVoxel-Docs`)
+   - `GITHUB_BRANCH` – Branch, aus dem geladen wird (Standard: `main`)
+3. Server starten:
+
+   ```
+   npm start
+   ```
+4. Im Browser `http://localhost:3000/` aufrufen, um die `README.md` zu sehen. Weitere Pfade wie `/foo` laden `foo.md` aus dem festgelegten Repo.
+
+   Die Navigationsleiste oben enthält Links zur Startseite und zum GitHub-Repository.
+
+## Entwicklung
+
+Zurzeit existieren keine automatischen Tests; `npm test` gibt lediglich einen Hinweis aus.

--- a/bungeesystem/bungeesystem.md
+++ b/bungeesystem/bungeesystem.md
@@ -1,0 +1,3 @@
+# BungeeSystem
+
+Dokumentation für BungeeSystem.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "devvoxel-docs",
+  "version": "1.0.0",
+  "description": "Simple docs server that renders GitHub markdown",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo 'No tests implemented'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/playerdatasync/playerdatasync.md
+++ b/playerdatasync/playerdatasync.md
@@ -1,0 +1,3 @@
+# PlayerDataSync
+
+Dokumentation für PlayerDataSync.

--- a/server.js
+++ b/server.js
@@ -1,0 +1,53 @@
+const http = require('http');
+const url = require('url');
+
+const owner = process.env.GITHUB_OWNER || 'DevVoxel';
+const repo = process.env.GITHUB_REPO || 'DevVoxel-Docs';
+const branch = process.env.GITHUB_BRANCH || 'main';
+const port = process.env.PORT || 3000;
+
+async function fetchMarkdown(pathname) {
+  const filePath = pathname === '/' ? 'README.md' : `${pathname.slice(1)}.md`;
+  const rawUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${filePath}`;
+  const resp = await fetch(rawUrl);
+  if (!resp.ok) {
+    throw new Error(`Request failed: ${resp.status}`);
+  }
+  return await resp.text();
+}
+
+function renderHTML(md, sidebarMd) {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Docs</title><style>body{margin:0;font-family:sans-serif;}nav{background:#333;color:#fff;padding:10px;}nav a{color:#fff;margin-right:10px;text-decoration:none;}#main{display:flex;}#sidebar{width:200px;padding:10px;background:#f0f0f0;}#content{flex:1;padding:10px;}</style></head><body><nav><a href="/">Home</a><a href="https://github.com/${owner}/${repo}" target="_blank">GitHub</a></nav><div id="main"><div id="sidebar"></div><div id="content"></div></div><script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script><script>const contentMD=${JSON.stringify(md)};const sidebarMD=${JSON.stringify(sidebarMd)};document.getElementById('content').innerHTML=marked.parse(contentMD);document.getElementById('sidebar').innerHTML=marked.parse(sidebarMD);</script></body></html>`;
+}
+
+if (process.argv.includes('--test')) {
+  Promise.all([fetchMarkdown('/'), fetchMarkdown('/sidebar')])
+    .then(([md]) => {
+      console.log(md.split('\n')[0] || 'empty file');
+    })
+    .catch(err => {
+      console.error(err.message);
+      process.exit(1);
+    });
+  return;
+}
+
+const server = http.createServer(async (req, res) => {
+    try {
+      const pathname = url.parse(req.url).pathname;
+      const [md, sidebarMd] = await Promise.all([
+        fetchMarkdown(pathname),
+        fetchMarkdown('/sidebar')
+      ]);
+      const html = renderHTML(md, sidebarMd);
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(html);
+    } catch (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Document not found');
+    }
+  });
+
+server.listen(port, () => {
+  console.log(`Docs server running on http://localhost:${port}`);
+});

--- a/sidebar.md
+++ b/sidebar.md
@@ -1,0 +1,4 @@
+# Navigation
+
+- [PlayerDataSync](/playerdatasync/playerdatasync)
+- [BungeeSystem](/bungeesystem/bungeesystem)


### PR DESCRIPTION
## Summary
- build simple Node.js server that fetches markdown from a GitHub repository and renders it as HTML
- document usage and environment variables in README
- ignore node_modules and add minimal npm scripts
- serve sidebar from markdown file and include sample doc pages with navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a07de6bf28832e8f06794e68290383