### PR TITLE
Serve local markdown with auto updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,15 @@
 ---
 
 ✨ *DevVoxel – powering the future of Minecraft servers.*
+
+---
+
+## 📚 Local Docs Server
+
+This repository contains a lightweight Node.js server that renders the Markdown files in this project. The server reads the files from disk and periodically runs `git pull` in the background to fetch updates from GitHub.
+
+```bash
+npm start
+```
+
+By default the repository is checked for updates every five minutes. Set `UPDATE_INTERVAL_MS` to override the interval (milliseconds).


### PR DESCRIPTION
## Summary
- load markdown files from disk with nested path fallback
- periodically pull repository updates in the background
- document local docs server and update interval

## Testing
- `npm test`
- `node server.js --test`
- `curl -I http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68a0820ea8e0832ea25991ff06ebb131